### PR TITLE
cffi - new version, python.h needed for compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ FROM node:6.9.1
 
 RUN apt-get update
 
-RUN apt-get install -y python python-pip
+RUN apt-get install -y python-pip python-dev
 
+RUN pip install --upgrade cffi
 RUN pip install httpbin gunicorn
 
 RUN npm install crawler -g


### PR DESCRIPTION
I was following the docker-tut in the bottom of the doc
This makes the image build afaic.