### PR TITLE
use python3 and later node-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 # Use the official Docker images
 # https://registry.hub.docker.com/_/node/
 #
-FROM node:6.9.1
+FROM node:9.3.0-stretch
 
 RUN apt-get update
 
-RUN apt-get install -y python-pip python-dev
+RUN apt-get install -y python3-pip python3-dev
 
-RUN pip install --upgrade cffi
-RUN pip install httpbin gunicorn
+RUN pip3 install --upgrade cffi
+RUN pip3 install httpbin gunicorn
+
 
 RUN npm install crawler -g


### PR DESCRIPTION
It can now build the image and run the tests
I chose the latest node-image on stretch, so apt is still good.
enum is python 3, and stretch seems to be on 3.5. 
In my opinion it is easiest to have python ~ 2.7 or >3.5